### PR TITLE
Invalidate all sensors on shutdown

### DIFF
--- a/companion.go
+++ b/companion.go
@@ -68,7 +68,12 @@ func (c *Companion) RunBackgroundProcesses(ctx context.Context, wg *sync.WaitGro
 // UpdateCompanionRunningState updates the companion running state.
 func (c *Companion) UpdateCompanionRunningState(ctx context.Context, wg *sync.WaitGroup) {
 	update := func(state bool) {
-		err := c.api.UpdateSensorData(context.Background(), []api.UpdateSensorDataRequest{{
+		bgCtx := context.Background()
+		if state == false {
+			log.Printf("Invalidating all sensors")
+			c.InvalidateAllSensors(bgCtx)
+		}
+		err := c.api.UpdateSensorData(bgCtx, []api.UpdateSensorDataRequest{{
 			State:    state,
 			Type:     "binary_sensor",
 			Icon:     "mdi:heart-pulse",
@@ -86,4 +91,32 @@ func (c *Companion) UpdateCompanionRunningState(ctx context.Context, wg *sync.Wa
 	}()
 
 	<-ctx.Done()
+}
+
+func (c *Companion) InvalidateAllSensors(ctx context.Context) {
+	outputs := entity.NewOutputs()
+
+	// Invalidate every registered sensor
+	for _, sensor := range c.sensors {
+		sensor.Invalidate(&outputs)
+	}
+
+	// Build one request to send all updated values to Home Assistant.
+	var data []api.UpdateSensorDataRequest
+	for _, output := range outputs.Data {
+		if output.Payload == nil {
+			continue
+		}
+		data = append(data, api.UpdateSensorDataRequest{
+			Type:     output.Sensor.Type,
+			State:    output.Payload.State,
+			UniqueId: output.Sensor.UniqueID,
+			Icon:     output.Sensor.Icon,
+		})
+	}
+
+	err := c.api.UpdateSensorData(ctx, data)
+	if err != nil {
+		log.Printf("failed to update sensor data: %s", err)
+	}
 }

--- a/companion.go
+++ b/companion.go
@@ -69,7 +69,7 @@ func (c *Companion) RunBackgroundProcesses(ctx context.Context, wg *sync.WaitGro
 func (c *Companion) UpdateCompanionRunningState(ctx context.Context, wg *sync.WaitGroup) {
 	update := func(state bool) {
 		bgCtx := context.Background()
-		if state == false {
+		if !state {
 			log.Printf("Invalidating all sensors")
 			c.InvalidateAllSensors(bgCtx)
 		}

--- a/entity/sensor.go
+++ b/entity/sensor.go
@@ -65,3 +65,11 @@ func (s Sensor) Update(ctx context.Context, wg *sync.WaitGroup, outputs *Outputs
 	log.Printf("received Payload for %s: %+v", s.UniqueID, value)
 	outputs.Add(Output{Sensor: s, Payload: value})
 }
+
+// Invalidate sensor by settings its state to unavailable
+func (s Sensor) Invalidate(outputs *Outputs) {
+	p := NewPayload()
+	p.State = "unavailable"
+	log.Printf("received p for %s: %+v", s.UniqueID, p)
+	outputs.Add(Output{Sensor: s, Payload: p})
+}


### PR DESCRIPTION
Currently, all sensors keep their last state when hacompanion shuts down, which is a bit unusual for Home Assistant.
This ensures all sensor states are set to `unavailable` when hacompanion exits.

Not knowing if or when a sensor is "up to date" makes it hard to create automations and the history graphs contain a lot of plateaux when the host running hacompanion goes down. This should fix it :)

