### PR TITLE
Guess push_url if not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ the configuration:
    the end of the page.
 1. Update your `~/.config/hacompanion.toml` file's `[homeassistant]` section with the generated `token`.
 1. Set the display name of your device (`device_name`) and the URL of your Home Assistant instance (`host`).
-1. If you plan to receive notifications from Home Assistant on your Desktop, change the `push_url` setting under `[notifications]` to point
-   to your local IP address.
+1. To receive notifications on a specific IP address you may need to change the 
+`push_url` and `listen` settings under `[notifications]` to point respectively 
+to your local IP address and the listen port. Without any value hacompanion will 
+use your default NIC and listen on port `8080`.
 1. Configure all sensors in the configuration file as you see fit.
 1. Run the companion by executing `hacompanion` (use the `-config=/path/to/config` flag to pass the path to a custom configuration
    file, `~/.config/hacompanion.toml` is used by default).

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"hacompanion/entity"
+	"log"
 	"net"
 )
 
@@ -57,7 +58,7 @@ func (c Config) GetPushUrl() (string, error) {
 
 	localIp, err := getLocalIp()
 	if err != nil {
-		fmt.Errorf("failed to determine local IP. Please set notifications.push_url in your config")
+		log.Println("failed to determine local IP. Please set notifications.push_url in your config")
 		return "", err
 	}
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,10 @@
 package main
 
-import "hacompanion/entity"
+import (
+	"fmt"
+	"hacompanion/entity"
+	"net"
+)
 
 // Config contains all values from the configuration file.
 type Config struct {
@@ -25,4 +29,37 @@ type companionConfig struct {
 type notificationsConfig struct {
 	Listen  string `toml:"listen"`
 	PushURL string `toml:"push_url"`
+}
+
+func getLocalIp() (string, error) {
+	// Credit: https://gist.github.com/jniltinho/9787946?permalink_comment_id=2243615#gistcomment-2243615
+	conn, err := net.Dial("udp", "1.1.1.1:80")
+	if err != nil {
+		return "", err
+	}
+
+	defer conn.Close()
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP.String(), nil
+}
+
+// GetPushUrl returns the pushUrl if set in the config or tries to guess it
+func (c Config) GetPushUrl() (string, error) {
+	// Use whatever is set in the config file if set
+	if c.Notifications.PushURL != "" {
+		return c.Notifications.PushURL, nil
+	}
+	// Get listen port
+	port := ":8080"
+	if c.Notifications.Listen != "" {
+		port = c.Notifications.Listen
+	}
+
+	localIp, err := getLocalIp()
+	if err != nil {
+		fmt.Errorf("failed to determine local IP. Please set notifications.push_url in your config")
+		return "", err
+	}
+
+	return fmt.Sprintf("http://%s%s/notifications", localIp, port), nil
 }

--- a/main.go
+++ b/main.go
@@ -297,6 +297,11 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 	id := util.RandomString(8)
 	token := util.RandomString(8)
 
+	pushUrl, err := k.config.GetPushUrl()
+	if err != nil {
+		fmt.Errorf("Push notifications will not work with your current config")
+	}
+
 	registration, err := k.api.RegisterDevice(ctx, api.RegisterDeviceRequest{
 		DeviceID:           id,
 		AppID:              "homeassistant-desktop-companion",
@@ -306,7 +311,7 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 		SupportsEncryption: false,
 		AppData: api.AppData{
 			PushToken: token,
-			PushURL:   k.config.Notifications.PushURL,
+			PushURL:   pushUrl,
 		},
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -299,7 +299,7 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 
 	pushUrl, err := k.config.GetPushUrl()
 	if err != nil {
-		fmt.Errorf("Push notifications will not work with your current config")
+		log.Println("Push notifications will not work with your current config")
 	}
 
 	registration, err := k.api.RegisterDevice(ctx, api.RegisterDeviceRequest{


### PR DESCRIPTION
Sorry for showering you in PRs!
This one tries to guess the right push URL if not explicitly set in the config.

Quick note: #10 will need to get updated once this is merged to leverage the same functionality (ie update the `push_url` on startup if the device is already registered)