### PR TITLE
Fix Last Boot sensor

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -50,7 +50,6 @@ var sensorDefinitions = map[string]func(m entity.Meta) entity.SensorDefinition{
 			Type:        "sensor",
 			Icon:        "mdi:sort-clock-descending",
 			DeviceClass: "timestamp",
-			Unit:        "ISO8601",
 		}
 	},
 	"load_avg": func(m entity.Meta) entity.SensorDefinition {


### PR DESCRIPTION
Don't know in what exact version of Home Assistant this broke, but at least since 2023.02 explicitly setting the unit of a timestamp results in the sensor data being set to "unknown".

Removing the `unit_of_measurement` restores the correct value.
