### PR TITLE
fix: create registration file parent dirs as needed (#27)

### DIFF
--- a/main.go
+++ b/main.go
@@ -345,6 +345,10 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 	if err != nil {
 		return registration, err
 	}
+	err = os.MkdirAll(filepath.Dir(k.config.Companion.RegistrationFile.Path), 0700)
+	if err != nil {
+		return registration, err
+	}
 	err = os.WriteFile(k.config.Companion.RegistrationFile.Path, j, 0600)
 	if err != nil {
 		return registration, err


### PR DESCRIPTION
Resolves #27 by creating all parent dirs (using `MkdirAll`) of configured registration file path as needed.

The alternatives I can think of would be:
1. Return a more specific error message, as the generic "file not found" can be a bit misleading (it took me a good half-hour to figure out why it couldn't just create the file).
    - **Pro:** Avoids the creation of crazy paths in the event of accidental concatenation (as in the original issue).
    - **Con:** The (admittedly minor) inconvenience of having to create and `chmod` any custom paths manually.
2. A potential compromise—only create one missing parent dir (using `Mkdir`), not the whole tree.
    - **Pro:** Should error on most crazy concatenation & expansion paths—most common expansions (~, ${HOME}, etc) are more than one level at userlevel.
    - **Con:** Won't catch accidental expansions for `/root` if running with sudo, as a system service, on some embedded/containerized systems, etc.

Wow, this is a long comment for a very simple pull request. :sweat_smile: Regardless, if one of those solutions would be preferred, just let me know and I'll pivot that way. Thanks for the great software!