### PR TITLE
refactor: update registration file creation logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"hacompanion/api"
 	"hacompanion/entity"
 	"hacompanion/sensor"
 	"hacompanion/util"
+	"io/fs"
 	"log"
 	"math/rand"
 	"os"
@@ -305,7 +307,7 @@ func (k *Kernel) getRegistration(ctx context.Context) (api.Registration, error) 
 		return registration, err
 	}
 	// Something went wrong, return the error.
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		return registration, err
 	}
 	return k.registerDevice(ctx)


### PR DESCRIPTION
Migrates registration file creation logic from the legacy `os.IsNotExist(err)` to the more modern and generally recommended `errors.Is(err, fs.ErrNotExist)`. Tested, works as intended in both the cases of the file not existing and its parent dirs not existing ([related pull request](https://github.com/tobias-kuendig/hacompanion/pull/31)).