### PR TITLE
style: further tidying employing go doc 1.19+ spec and features

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -53,7 +53,7 @@ type RegisterSensorRequest struct {
 	Name              string            `json:"name"`
 	State             string            `json:"state,omitempty"`
 	Type              string            `json:"type"`
-	UniqueId          string            `json:"unique_id"`
+	UniqueID          string            `json:"unique_id"`
 	UnitOfMeasurement string            `json:"unit_of_measurement"`
 }
 
@@ -67,7 +67,7 @@ type UpdateSensorDataRequest struct {
 	Icon       string                 `json:"icon"`
 	State      interface{}            `json:"state"`
 	Type       string                 `json:"type"`
-	UniqueId   string                 `json:"unique_id"`
+	UniqueID   string                 `json:"unique_id"`
 }
 
 type updateSensorRequestPayload struct {
@@ -240,7 +240,7 @@ func (api *API) RegisterSensors(ctx context.Context, sensors []entity.Sensor) er
 			DeviceClass:       sensor.DeviceClass,
 			Icon:              sensor.Icon,
 			Name:              sensor.Name,
-			UniqueId:          sensor.UniqueID,
+			UniqueID:          sensor.UniqueID,
 			UnitOfMeasurement: sensor.Unit,
 		})
 		if err != nil {

--- a/companion.go
+++ b/companion.go
@@ -46,7 +46,7 @@ func (c *Companion) UpdateSensorData(ctx context.Context) {
 			Type:       output.Sensor.Type,
 			State:      output.Payload.State,
 			Attributes: output.Payload.Attributes,
-			UniqueId:   output.Sensor.UniqueID,
+			UniqueID:   output.Sensor.UniqueID,
 			Icon:       icon,
 		})
 	}
@@ -81,7 +81,7 @@ func (c *Companion) UpdateCompanionRunningState(ctx context.Context, wg *sync.Wa
 			State:    state,
 			Type:     "binary_sensor",
 			Icon:     "mdi:heart-pulse",
-			UniqueId: "companion_running",
+			UniqueID: "companion_running",
 		}})
 		if err != nil {
 			log.Printf("failed to update companion_running state: %s", err)
@@ -114,7 +114,7 @@ func (c *Companion) InvalidateAllSensors(ctx context.Context) {
 		data = append(data, api.UpdateSensorDataRequest{
 			Type:     output.Sensor.Type,
 			State:    output.Payload.State,
-			UniqueId: output.Sensor.UniqueID,
+			UniqueID: output.Sensor.UniqueID,
 			Icon:     output.Sensor.Icon,
 		})
 	}

--- a/companion.go
+++ b/companion.go
@@ -69,7 +69,7 @@ func (c *Companion) RunBackgroundProcesses(ctx context.Context, wg *sync.WaitGro
 	processWg.Wait()
 }
 
-// UpdateCompanionRunningState() updates the Companion running state.
+// UpdateCompanionRunningState updates the Companion running state.
 func (c *Companion) UpdateCompanionRunningState(ctx context.Context, wg *sync.WaitGroup) {
 	update := func(state bool) {
 		bgCtx := context.Background()
@@ -100,7 +100,7 @@ func (c *Companion) UpdateCompanionRunningState(ctx context.Context, wg *sync.Wa
 func (c *Companion) InvalidateAllSensors(ctx context.Context) {
 	outputs := entity.NewOutputs()
 
-	// Invalidate every registered sensor
+	// Invalidate every registered sensor.
 	for _, sensor := range c.sensors {
 		sensor.Invalidate(&outputs)
 	}

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ type notificationsConfig struct {
 	PushURL string `toml:"push_url"`
 }
 
-func getLocalIp() (string, error) {
+func getLocalIP() (string, error) {
 	// [Source]: https://gist.github.com/jniltinho/9787946?permalink_comment_id=2243615#gistcomment-2243615
 	conn, err := net.Dial("udp", "1.1.1.1:80")
 	if err != nil {
@@ -44,8 +44,8 @@ func getLocalIp() (string, error) {
 	return localAddr.IP.String(), nil
 }
 
-// GetPushUrl returns the pushUrl if set in the config, and if not tries to guess it.
-func (c Config) GetPushUrl() (string, error) {
+// GetPushURL returns the pushURL if set in the config, and if not tries to guess it.
+func (c Config) GetPushURL() (string, error) {
 	if c.Notifications.PushURL != "" {
 		return c.Notifications.PushURL, nil
 	}
@@ -55,11 +55,11 @@ func (c Config) GetPushUrl() (string, error) {
 		port = c.Notifications.Listen
 	}
 
-	localIp, err := getLocalIp()
+	localIP, err := getLocalIP()
 	if err != nil {
 		log.Println("failed to determine local IP. Please set notifications.push_url in your config")
 		return "", err
 	}
 
-	return fmt.Sprintf("http://%s%s/notifications", localIp, port), nil
+	return fmt.Sprintf("http://%s%s/notifications", localIP, port), nil
 }

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ type notificationsConfig struct {
 }
 
 func getLocalIp() (string, error) {
-	// Credit: https://gist.github.com/jniltinho/9787946?permalink_comment_id=2243615#gistcomment-2243615
+	// [Source]: https://gist.github.com/jniltinho/9787946?permalink_comment_id=2243615#gistcomment-2243615
 	conn, err := net.Dial("udp", "1.1.1.1:80")
 	if err != nil {
 		return "", err
@@ -44,9 +44,8 @@ func getLocalIp() (string, error) {
 	return localAddr.IP.String(), nil
 }
 
-// GetPushUrl() returns the pushUrl if set in the config or tries to guess it.
+// GetPushUrl returns the pushUrl if set in the config, and if not tries to guess it.
 func (c Config) GetPushUrl() (string, error) {
-	// Use whatever is set in the config file if set
 	if c.Notifications.PushURL != "" {
 		return c.Notifications.PushURL, nil
 	}

--- a/entity/sensor.go
+++ b/entity/sensor.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 )
 
-// Runner{} is used to gather data of any kind.
+// Runner is used to gather data of any kind.
 type Runner interface {
 	Run(ctx context.Context) (*Payload, error)
 }
 
-// SensorDefinition{} contains all Home Assistant attributes.
+// SensorDefinition contains all Home Assistant attributes.
 type SensorDefinition struct {
 	Type        string
 	Runner      func(Meta) Runner
@@ -21,14 +21,14 @@ type SensorDefinition struct {
 	Unit        string
 }
 
-// SensorConfig{} contains the configuration for a single sensor.
+// SensorConfig contains the configuration for a single sensor.
 type SensorConfig struct {
 	Enabled bool
 	Name    string
 	Meta    map[string]interface{}
 }
 
-// ScriptConfig{} contains the definition of a custom script sensor.
+// ScriptConfig contains the definition of a custom script sensor.
 type ScriptConfig struct {
 	Path              string
 	Name              string
@@ -38,7 +38,7 @@ type ScriptConfig struct {
 	DeviceClass       string `toml:"device_class"`
 }
 
-// Sensor{} is a concrete instance of a sensor defined in the config file.
+// Sensor is a concrete instance of a sensor defined in the config file.
 // Its Runner is run to gather data.
 type Sensor struct {
 	Type        string
@@ -54,7 +54,7 @@ func (s Sensor) String() string {
 	return fmt.Sprintf("%s (%s)", s.Name, s.UniqueID)
 }
 
-// Update() runs a Sensor's Runner and returns the outputs.
+// Update runs a Sensor's Runner and returns the outputs.
 func (s Sensor) Update(ctx context.Context, wg *sync.WaitGroup, outputs *Outputs) {
 	defer wg.Done()
 	value, err := s.Runner.Run(ctx)
@@ -66,7 +66,7 @@ func (s Sensor) Update(ctx context.Context, wg *sync.WaitGroup, outputs *Outputs
 	outputs.Add(Output{Sensor: s, Payload: value})
 }
 
-// Invalidate() sets stale sensor states to unavailable
+// Invalidate sets the state of the given sensor(s) to unavailable.
 func (s Sensor) Invalidate(outputs *Outputs) {
 	p := NewPayload()
 	p.State = "unavailable"

--- a/main.go
+++ b/main.go
@@ -330,7 +330,7 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 	id := util.RandomString(8)
 	token := util.RandomString(8)
 
-	pushUrl, err := k.config.GetPushUrl()
+	pushURL, err := k.config.GetPushURL()
 	if err != nil {
 		log.Println("Push notifications will not work with your current config")
 	}
@@ -338,7 +338,7 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 	registration, err := k.api.RegisterDevice(ctx, api.RegisterDeviceRequest{
 		AppData: api.AppData{
 			PushToken: token,
-			PushURL:   pushUrl,
+			PushURL:   pushURL,
 		},
 		AppID:              AppID,
 		AppName:            AppName,
@@ -372,14 +372,14 @@ func (k *Kernel) registerDevice(ctx context.Context) (api.Registration, error) {
 
 // updateRegistration updates app registration data.
 func (k *Kernel) updateRegistration(ctx context.Context, registration api.Registration) error {
-	pushUrl, err := k.config.GetPushUrl()
+	pushURL, err := k.config.GetPushURL()
 	if err != nil {
 		log.Println("Push notifications will not work with your current config")
 	}
 	err = k.api.UpdateRegistration(ctx, api.UpdateRegistrationRequest{
 		AppData: api.AppData{
 			PushToken: registration.PushToken,
-			PushURL:   pushUrl,
+			PushURL:   pushURL,
 		},
 		AppVersion:   Version,
 		DeviceName:   k.api.DeviceName,

--- a/notifications.go
+++ b/notifications.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strconv"
+	"time"
 
 	"hacompanion/api"
 	"hacompanion/util"
@@ -30,6 +31,11 @@ func NewNotificationServer(registration api.Registration, address string) *Notif
 	s.Server = &http.Server{
 		Addr:    s.address,
 		Handler: s.mux,
+		// Set some reasonable timeouts, mostly to resolve linter
+		// warnings about the potential for a slowloris DoS.
+		ReadHeaderTimeout: time.Duration(10) * time.Second,
+		ReadTimeout:       time.Duration(20) * time.Second,
+		WriteTimeout:      time.Duration(20) * time.Second,
 	}
 	return s
 }
@@ -57,7 +63,7 @@ func (s NotificationServer) Listen(ctx context.Context) {
 			return
 		}
 		log.Println("notification sent successfully")
-		w.WriteHeader(201)
+		w.WriteHeader(http.StatusCreated)
 		util.RespondSuccess(w)
 	})
 

--- a/sensor/cpu.go
+++ b/sensor/cpu.go
@@ -16,7 +16,9 @@ import (
 )
 
 var (
-	reCPUTemp  = regexp.MustCompile(`(?m)(Package id|Core \d)[\s\d]*:\s+.?([\d\.]+)°`)
+	reCPUTemp = regexp.MustCompile(`(?m)(temp1|Package id|Core \d)[\s\d]*:\s+.?([\d\.]+)°`)
+	// This is currently unused.
+	//reCPUTemp2 = regexp.MustCompile(`(?mi)^\s?(?P<name>[^:]+):\s+(?P<value>\d+)`)
 	reCPUUsage = regexp.MustCompile(`(?m)^\s*cpu(\d+)?.*`)
 )
 
@@ -98,7 +100,7 @@ func (c CPUUsage) process(outputs []string) (*entity.Payload, error) {
 	// Parse out the usage deltas from the stats output.
 	stats := map[string][]stat{}
 	for i, output := range outputs {
-		// Returns measurement for a single core.
+		// Return a measurement for a single core.
 		matches := reCPUUsage.FindAllStringSubmatch(output, -1)
 		for _, submatch := range matches {
 			match := strings.TrimSpace(submatch[0])
@@ -130,7 +132,7 @@ func (c CPUUsage) process(outputs []string) (*entity.Payload, error) {
 			}
 		}
 	}
-	// Calculate the percentage values per core.
+	// Calculate the usage per core as a percentage.
 	for cpu, value := range stats {
 		u := value[1].usage - value[0].usage
 		t := value[1].total - value[0].total

--- a/sensor/memory.go
+++ b/sensor/memory.go
@@ -41,7 +41,7 @@ func (m Memory) process(output string) (*entity.Payload, error) {
 		if err != nil {
 			continue
 		}
-		// convert kb to MB
+		// Convert kb to MB.
 		mb := util.RoundToTwoDecimals(float64(kb) / 1024)
 		switch strings.TrimSpace(match[1]) {
 		case "MemFree":
@@ -57,7 +57,7 @@ func (m Memory) process(output string) (*entity.Payload, error) {
 		}
 	}
 	if p.State == "" {
-		return nil, fmt.Errorf("could not detrmine memory state based on /proc/meminfo: %s", output)
+		return nil, fmt.Errorf("could not determine memory state based on /proc/meminfo: %s", output)
 	}
 	return p, nil
 }

--- a/sensor/script.go
+++ b/sensor/script.go
@@ -37,20 +37,20 @@ func (s Script) Run(ctx context.Context) (*entity.Payload, error) {
 	for sc.Scan() {
 		n++
 		line := strings.TrimSpace(sc.Text())
-		// First line has to contain state.
+		// Read in first line as the state.
 		if n == 1 {
 			if s.cfg.Type == "binary_sensor" {
-				// Binary sensor -> convert string to bool
+				// Convert string to bool for a binary sensor.
 				line_lower := strings.ToLower(line)
 				strtobool := map[string]bool{"on": true, "true": true, "yes": true}
 				p.State = strtobool[line_lower]
 			} else {
-				// Regular sensor
+				// No conversion needed for a regular sensor.
 				p.State = line
 			}
 			continue
 		}
-		// Other lines are attributes.
+		// Read in any additional lines as attributes.
 		parts := strings.Split(line, ":")
 		if len(parts) < 2 {
 			log.Printf("ignoring custom script line with less than two parts: %s\n", line)

--- a/sensor/script.go
+++ b/sensor/script.go
@@ -41,9 +41,9 @@ func (s Script) Run(ctx context.Context) (*entity.Payload, error) {
 		if n == 1 {
 			if s.cfg.Type == "binary_sensor" {
 				// Convert string to bool for a binary sensor.
-				line_lower := strings.ToLower(line)
+				lineLower := strings.ToLower(line)
 				strtobool := map[string]bool{"on": true, "true": true, "yes": true}
-				p.State = strtobool[line_lower]
+				p.State = strtobool[lineLower]
 			} else {
 				// No conversion needed for a regular sensor.
 				p.State = line

--- a/util/http.go
+++ b/util/http.go
@@ -7,7 +7,8 @@ import (
 )
 
 // RespondError returns a JSON error response.
-// nolint:errcheck
+//
+//nolint:errcheck
 func RespondError(w http.ResponseWriter, error string, status int) {
 	var resp struct {
 		Error string `json:"errorMessage"`
@@ -25,7 +26,8 @@ func RespondError(w http.ResponseWriter, error string, status int) {
 // Because Home Assistant errors without a rateLimits response and
 // there is no rate limiting implemented on our side, we return a
 // dummy response with RespondSuccess.
-// nolint:errcheck
+//
+//nolint:errcheck
 func RespondSuccess(w http.ResponseWriter) {
 	w.Write([]byte(`
 		{

--- a/util/http.go
+++ b/util/http.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-// RespondError return a JSON error response.
+// RespondError returns a JSON error response.
 // nolint:errcheck
 func RespondError(w http.ResponseWriter, error string, status int) {
 	var resp struct {
@@ -22,8 +22,9 @@ func RespondError(w http.ResponseWriter, error string, status int) {
 	w.Write(b)
 }
 
-// Home Assistant errors without a rateLimits response.
-// There is no rate limiting implemented on our side so we return a dummy response.
+// Because Home Assistant errors without a rateLimits response and
+// there is no rate limiting implemented on our side, we return a
+// dummy response with RespondSuccess.
 // nolint:errcheck
 func RespondSuccess(w http.ResponseWriter) {
 	w.Write([]byte(`


### PR DESCRIPTION
I did a quick pass to ensure the doc comments conform to go doc spec, and reworded some for clarity (using 1.19 features since you bumped the version). Thanks again for the link.

I do have a couple actual features in mind I'd like to try my hand at implementing and submitting if I can, not just endless obsessing over comment style, I promise. :smile: I just like to get all the styling stuff out of the way first when I find a project to contribute to, otherwise it tends to be quite a nuisance to keep those tweaks from slipping into unrelated feature commits if I get to that point.