### PR TITLE
Add Arch Linux binary install option to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ You can download a compiled binary [from the releases page](https://github.com/t
 
 Just download the `_binary` file for your architecture and copy it to `~/.local/bin/hacompanion` (or any other path on your system).
 
+Arch Linux users have the option to install the binary as an AUR package. Eg:
+```
+yay -Sy hacompanion
+```
+
 You can now start the companion with the `hacompanion` command. But before doing so, you have to set up
 the configuration:
 


### PR DESCRIPTION
Using a package manager makes life much easier regarding installing and keeping applications up-to-date. Arch Linux AUR package management makes it possible to install and keep `hacompanion` up-to-date. This install option should be documented as a viable option.