### PR TITLE
fix: CPU temperature on AMD machines

### DIFF
--- a/sensor/cpu.go
+++ b/sensor/cpu.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	reCPUTemp = regexp.MustCompile(`(?m)(temp1|Package id|Core \d)[\s\d]*:\s+.?([\d\.]+)°`)
+	reCPUTemp = regexp.MustCompile(`(?m)(temp1|Package id|Core \d|CPU)[\s\d]*:\s+.?([\d\.]+)°`)
 	// This is currently unused.
 	//reCPUTemp2 = regexp.MustCompile(`(?mi)^\s?(?P<name>[^:]+):\s+(?P<value>\d+)`)
 	reCPUUsage = regexp.MustCompile(`(?m)^\s*cpu(\d+)?.*`)
@@ -56,7 +56,7 @@ func (c CPUTemp) process(output string) (*entity.Payload, error) {
 		if len(match) < 3 {
 			return nil, fmt.Errorf("invalid output form lm-sensors received: %s", output)
 		}
-		if strings.EqualFold(match[1], "Package id") {
+		if strings.EqualFold(match[1], "Package id") || strings.EqualFold(match[1], "CPU") {
 			p.State = match[2]
 		} else {
 			p.Attributes[util.ToSnakeCase(match[1])] = match[2]

--- a/sensor/cpu_test.go
+++ b/sensor/cpu_test.go
@@ -66,6 +66,7 @@ func TestCPUTemp(t *testing.T) {
 			"core_3": "37.0",
 			"core_4": "38.0",
 			"core_5": "39.0",
+			"temp_1": "37.0",
 		},
 	}
 


### PR DESCRIPTION
Noticed that the CPU temps on my Lenovo X13 Gen1 were not reported correctly (state: `unknown`).

Here's the output of `sensors` on that machine:

```
amdgpu-pci-0600
Adapter: PCI adapter
vddgfx:      812.00 mV
vddnb:       612.00 mV
edge:         +44.0°C
PPT:           5.00 W

thinkpad-isa-0000
Adapter: ISA adapter
fan1:           0 RPM
fan2:           0 RPM
CPU:          +44.0°C
GPU:           +0.0°C
temp3:         +0.0°C
temp4:         +0.0°C
temp5:         +0.0°C
temp6:         +0.0°C
temp7:         +0.0°C
temp8:            N/A

nvme-pci-0100
Adapter: PCI adapter
Composite:    +32.9°C  (low  = -273.1°C, high = +83.8°C)
                       (crit = +84.8°C)
Sensor 1:     +32.9°C  (low  = -273.1°C, high = +65261.8°C)
Sensor 2:     +29.9°C  (low  = -273.1°C, high = +65261.8°C)

iwlwifi_1-virtual-0
Adapter: Virtual device
temp1:        +37.0°C

k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +44.4°C

BAT0-acpi-0
Adapter: ACPI interface
in0:          11.53 V
```

Notice that there's no `Package id` line, but a `CPU` one.
