### PR TITLE
Use degrees symbol

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -8,9 +8,9 @@ import (
 // sensorDefinitions is used to map the configuration to internal types.
 var sensorDefinitions = map[string]func(m entity.Meta) entity.SensorDefinition{
 	"cpu_temp": func(m entity.Meta) entity.SensorDefinition {
-		unit := "C"
+		unit := "°C"
 		if !m.GetBool("celsius") {
-			unit = "F"
+			unit = "°F"
 		}
 		return entity.SensorDefinition{
 			Type:        "sensor",


### PR DESCRIPTION
On my HA install, I got the following message:

```
Entity sensor.<hostname>_cpu_temperature (<class 'homeassistant.components.mobile_app.sensor.MobileAppSensor'>) is using native unit of measurement 'C' which is not a valid unit for the device class ('temperature') it is using; expected one of ['K', '°C', '°F']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mobile_app%22 
```

After changing it the sensor kept its history so I think we need not to implement some backwards compatible option.