### PR TITLE
Properly report CPU temperature on AMD systems

### DIFF
--- a/sensor/cpu.go
+++ b/sensor/cpu.go
@@ -56,7 +56,7 @@ func (c CPUTemp) process(output string) (*entity.Payload, error) {
 		if len(match) < 3 {
 			return nil, fmt.Errorf("invalid output form lm-sensors received: %s", output)
 		}
-		if strings.EqualFold(match[1], "Package id") || strings.EqualFold(match[1], "CPU") {
+		if strings.EqualFold(match[1], "Package id") || strings.EqualFold(match[1], "CPU") || strings.EqualFold(match[1], "Tctl") {
 			p.State = match[2]
 		} else {
 			p.Attributes[util.ToSnakeCase(match[1])] = match[2]

--- a/sensor/cpu.go
+++ b/sensor/cpu.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	reCPUTemp = regexp.MustCompile(`(?m)(temp1|Package id|Core \d|CPU)[\s\d]*:\s+.?([\d\.]+)°`)
+	reCPUTemp = regexp.MustCompile(`(?m)(temp1|Package id|Core \d|CPU|Tctl)[\s\d]*:\s+.?([\d\.]+)°`)
 	// This is currently unused.
 	//reCPUTemp2 = regexp.MustCompile(`(?mi)^\s?(?P<name>[^:]+):\s+(?P<value>\d+)`)
 	reCPUUsage = regexp.MustCompile(`(?m)^\s*cpu(\d+)?.*`)

--- a/sensor/cpu_test.go
+++ b/sensor/cpu_test.go
@@ -57,6 +57,10 @@ func TestCPUTemp(t *testing.T) {
 		pch_cannonlake-virtual-0
 		Adapter: Virtual device
 		temp1:        +37.0°C  
+
+		k10temp-pci-00c3
+		Adapter: PCI adapter
+		Tctl:         +39.6°C
 	`
 	output := &entity.Payload{
 		State: "99.0",
@@ -68,6 +72,7 @@ func TestCPUTemp(t *testing.T) {
 			"core_4": "38.0",
 			"core_5": "39.0",
 			"temp_1": "37.0",
+			"Tctl": "39.6",
 		},
 	}
 


### PR DESCRIPTION
Sensors output of CPU temperature for current AMD processors is currently not parsed correctly since it is not matched by the used regex expression:

```
k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +42.0°C  
Tccd1:        +37.0°C  
```

This pull request adds "Tctl" to the regex and corresponding processing function.