### PR TITLE
Skip emitting notification for "Clearing" command

### DIFF
--- a/notifications.go
+++ b/notifications.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"os/exec"
 	"os/user"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"hacompanion/api"
@@ -89,7 +91,7 @@ func (s NotificationServer) Listen(_ context.Context) {
 type Notification struct{}
 
 func (n *Notification) Send(ctx context.Context, title, message string, data api.PushNotificationData, uid string) error {
-	if message == "clear_notification" {
+	if slices.Contains([]string{"clear_notification", "remove_channel", "tts"}, strings.ToLower(message)) {
 		return nil
 	}
 


### PR DESCRIPTION
Home Assistant uses the following payloads for signaling specific commands:
- `message: clear_notification` for [signaling the OSes to clear an existing notification](https://companion.home-assistant.io/docs/notifications/notifications-basic#clearing). 
- `message: remove_channel` for [signaling the OSes to remove a notification channel](https://companion.home-assistant.io/docs/notifications/notifications-basic/#removing-a-channel). 
- `message: TTS` for [signaling the OSes to speak the notification](https://companion.home-assistant.io/docs/notifications/notifications-basic/#text-to-speech-notifications). 

These are not currently handled by hacompanion, making the OS to display a notification with the clear text on it.

This changes makes it so when the notification message is "clear_notification", "remove_channel" or "TTS", the Send function will now return early without displaying a notification.